### PR TITLE
Move OpenSSL verification utils into a separate file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ matrix:
 
 
 install:
+  - openssl version
   - cd ..
   - $TRAVIS_BUILD_DIR/tools/get_boost.sh $TRAVIS_BRANCH $TRAVIS_BUILD_DIR
   - cd boost-root

--- a/tests/Jamfile
+++ b/tests/Jamfile
@@ -21,6 +21,7 @@ project /boost/certify/tests
     <library>/boost/filesystem//boost_filesystem
     <library>ssl
     <library>crypto
+    <include>./extras/include
     <target-os>windows:<library>crypt32
     <define>BOOST_ALL_NO_LIB=1
     <define>BOOST_ASIO_DISABLE_BOOST_ARRAY=1
@@ -41,5 +42,5 @@ project /boost/certify/tests
 
 
 test-suite "certify" :
-  [ run rfc2818_verification.cpp ]
+  [ run rfc2818_verification_success.cpp ]
   ;

--- a/tests/extras/include/boost/certify/verification_utils.hpp
+++ b/tests/extras/include/boost/certify/verification_utils.hpp
@@ -1,13 +1,9 @@
 #include <boost/certify/rfc2818_verification.hpp>
 
-#include <boost/asio/connect.hpp>
-#include <boost/asio/io_context.hpp>
-#include <boost/asio/ip/tcp.hpp>
-#include <boost/asio/ssl.hpp>
-
-#include <boost/core/lightweight_test.hpp>
+#include <boost/asio/ssl/error.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
+#include <boost/system/error_code.hpp>
 
 namespace boost
 {
@@ -257,21 +253,3 @@ verify_chain(boost::filesystem::path const& chain_path,
 
 } // namespace certify
 } // namespace boost
-
-int
-main()
-{
-    boost::certify::certificate_store store;
-    store.set_default_paths();
-
-    int count = 0;
-    for (auto const& entry : boost::filesystem::directory_iterator{
-           "libs/certify/tests/res/chains/"})
-    {
-        boost::certify::verify_chain(entry.path(), store);
-        ++count;
-    }
-    BOOST_TEST(count > 0);
-
-    return boost::report_errors();
-}

--- a/tests/extras/include/boost/certify/verification_utils.hpp
+++ b/tests/extras/include/boost/certify/verification_utils.hpp
@@ -238,7 +238,7 @@ verify_callback(int preverified, X509_STORE_CTX* ctx)
 
 void
 verify_chain(boost::filesystem::path const& chain_path,
-             boost::certify::certificate_store& store)
+             boost::certify::certificate_store& store, system::error_code& ec)
 {
     if (!boost::filesystem::is_regular_file(chain_path))
         return;
@@ -248,7 +248,7 @@ verify_chain(boost::filesystem::path const& chain_path,
 
     ctx.set_verify_callback(
       boost::certify::rfc2818_verification{chain_path.stem().string()});
-    ctx.verify();
+    ctx.verify(ec);
 }
 
 } // namespace certify

--- a/tests/rfc2818_verification_success.cpp
+++ b/tests/rfc2818_verification_success.cpp
@@ -13,7 +13,10 @@ main()
     for (auto const& entry : boost::filesystem::directory_iterator{
            "libs/certify/tests/res/chains/"})
     {
-        boost::certify::verify_chain(entry.path(), store);
+        boost::system::error_code ec;
+        boost::certify::verify_chain(entry.path(), store, ec);
+        if (ec)
+            BOOST_ERROR((entry.path().string() + ": " + ec.message()).c_str());
         ++count;
     }
     BOOST_TEST(count > 0);

--- a/tests/rfc2818_verification_success.cpp
+++ b/tests/rfc2818_verification_success.cpp
@@ -6,6 +6,8 @@
 int
 main()
 {
+    ::SSL_library_init();
+
     boost::certify::certificate_store store;
     store.set_default_paths();
 

--- a/tests/rfc2818_verification_success.cpp
+++ b/tests/rfc2818_verification_success.cpp
@@ -1,0 +1,22 @@
+#include <boost/certify/rfc2818_verification.hpp>
+
+#include <boost/certify/verification_utils.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+int
+main()
+{
+    boost::certify::certificate_store store;
+    store.set_default_paths();
+
+    int count = 0;
+    for (auto const& entry : boost::filesystem::directory_iterator{
+           "libs/certify/tests/res/chains/"})
+    {
+        boost::certify::verify_chain(entry.path(), store);
+        ++count;
+    }
+    BOOST_TEST(count > 0);
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
This enables the verification code to be shared by other tests.