### PR TITLE
Doc work

### DIFF
--- a/doc/certify/reference/extensions.adoc
+++ b/doc/certify/reference/extensions.adoc
@@ -9,4 +9,44 @@ http://www.boost.org/LICENSE_1_0.txt
 
 = TLS extensions, `<boost/certify/extensions.hpp>`
 
+This file contains extensions to the implementation of `asio::ssl`.
+
 == TLS-SNI
+https://en.wikipedia.org/wiki/Server_Name_Indication[TLS-SNI] is an extension
+that enables a client to indicate to a server which hostname it is trying to
+connect to. Some servers require this an SNI hostname to be sent in a TLS
+handshake, because multiple hostnames may be served by the same public-facing
+IP, without requiring all those sites to use the same certificate.
+
+[source, c++]
+----
+template<class AsyncStream>
+boost::string_view
+sni_hostname(boost::asio::asio::ssl::stream<AsyncStream> const& stream);
+----
+
+Returns the SNI hostname set on the provided stream or a default
+constructed `string_view` if none was set.
+
+[source, c++]
+----
+template<class AsyncStream>
+void
+sni_hostname(boost::asio::asio::ssl::stream<AsyncStream>& stream,
+             std::string const& hostname,
+             boost::system::error_code& ec);
+----
+
+Sets the provided SNI hostname on the provided stream. On success, `ec` is
+cleared, on error it will contain an error.
+
+[source, c++]
+----
+template<class AsyncStream>
+void
+sni_hostname(asio::ssl::stream<AsyncStream>& stream,
+             std::string const& hostname);
+----
+
+Sets the provided SNI hostname on the provided stream. On error a
+`boost::system::system_error` is thrown.

--- a/doc/certify/reference/rfc2818_verification.adoc
+++ b/doc/certify/reference/rfc2818_verification.adoc
@@ -9,16 +9,6 @@ http://www.boost.org/LICENSE_1_0.txt
 
 = HTTPS verification, `<boost/certify/rfc2818_verification.hpp>`
 
-
-The `rfc2818_verification` class implements a callback that server
-authentication during a TLS handshake. Certificate verification is first
-performed using CA certificates imported into OpenSSL. If that fails because of
-missing CA certificates, the library will utilize platform specific APIs to try
-and complete the process. If verification passes and the peer's certificate
-chain is authentic, this callback will continue with the verification process,
-as specified in https://tools.ietf.org/html/rfc2818[RFC2818].
-
-
 [source, c++]
 ----
 class rfc2818_verification
@@ -32,3 +22,21 @@ public:
     std::string const& hostname() const;
 };
 ----
+
+The `rfc2818_verification` class implements a callback that performs server
+authentication during a TLS handshake. Certificate verification is first
+performed using CA certificates imported into OpenSSL. If that fails because of
+missing CA certificates, the library will utilize platform specific APIs to try
+and complete the process. If verification passes and the peer's certificate
+chain is authentic, this callback will continue with the verification process,
+as specified in https://tools.ietf.org/html/rfc2818[RFC2818].
+
+Example usage:
+[source, c++]
+----
+boost::asio::ssl::stream<boost::asio::tcp::socket> stream{/*...*/};
+stream.set_verify_callback(boost::certify::rfc2818_verification{"github.com"});
+----
+
+If verification, using the platform-specific API, fails, the handshake operation
+will fail with an error indicating that the certificate chain was self-signed.

--- a/include/boost/certify/extensions.hpp
+++ b/include/boost/certify/extensions.hpp
@@ -11,15 +11,20 @@ namespace boost
 namespace certify
 {
 
-template<class AsyncReadStream>
+template<class AsyncStream>
 string_view
-sni_hostname(asio::ssl::stream<AsyncReadStream> const& stream);
+sni_hostname(asio::ssl::stream<AsyncStream> const& stream);
 
-template<class AsyncReadStream>
+template<class AsyncStream>
 void
-sni_hostname(asio::ssl::stream<AsyncReadStream>& stream,
+sni_hostname(asio::ssl::stream<AsyncStream>& stream,
              std::string const& hostname,
              system::error_code& ec);
+
+template<class AsyncStream>
+void
+sni_hostname(asio::ssl::stream<AsyncStream>& stream,
+             std::string const& hostname);
 
 } // namespace certify
 } // namespace boost

--- a/include/boost/certify/impl/extensions.hpp
+++ b/include/boost/certify/impl/extensions.hpp
@@ -8,21 +8,21 @@ namespace boost
 namespace certify
 {
 
-template<class AsyncReadStream>
+template<class AsyncStream>
 string_view
-sni_hostname(asio::ssl::stream<AsyncReadStream> const& stream)
+sni_hostname(asio::ssl::stream<AsyncStream> const& stream)
 {
     auto handle =
-      const_cast<asio::ssl::stream<AsyncReadStream>&>(stream).native_handle();
+      const_cast<asio::ssl::stream<AsyncStream>&>(stream).native_handle();
     auto* hostname = SSL_get_servername(handle, TLSEXT_NAMETYPE_host_name);
     if (hostname == nullptr)
         return string_view{};
     return {hostname};
 }
 
-template<class AsyncReadStream>
+template<class AsyncStream>
 void
-sni_hostname(asio::ssl::stream<AsyncReadStream>& stream,
+sni_hostname(asio::ssl::stream<AsyncStream>& stream,
              std::string const& hostname,
              system::error_code& ec)
 {
@@ -35,9 +35,9 @@ sni_hostname(asio::ssl::stream<AsyncReadStream>& stream,
         ec = {};
 }
 
-template<class AsyncReadStream>
+template<class AsyncStream>
 void
-sni_hostname(asio::ssl::stream<AsyncReadStream>& stream,
+sni_hostname(asio::ssl::stream<AsyncStream>& stream,
              std::string const& hostname)
 {
     system::error_code ec;


### PR DESCRIPTION
* Extend documentation for TLS-SNI and rfc2818_verification
* Add missing throwing overload of `sni_hostname`