### PR TITLE
Certificate status cache

### DIFF
--- a/include/boost/certify/detail/status_cache.hpp
+++ b/include/boost/certify/detail/status_cache.hpp
@@ -1,0 +1,71 @@
+#ifndef BOOST_CERTIFY_STATUS_CACHE_HPP
+#define BOOST_CERTIFY_STATUS_CACHE_HPP
+
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace boost
+{
+namespace certify
+{
+
+enum class certificate_status
+{
+    valid,
+    revoked,
+    unknown
+};
+
+class status_cache
+{
+public:
+    using clock_type = std::chrono::system_clock;
+    using time_point = std::chrono::system_clock::time_point;
+
+    certificate_status check(std::string const& spki) const
+    {
+        std::lock_guard<std::mutex> guard{mtx_};
+        auto it = status_cache_.find(spki);
+        if (it == status_cache_.end())
+            return certificate_status::unknown;
+        if (it->second.valid_until <= clock_type::now())
+            return certificate_status::unknown;
+
+        return it->second.status;
+    }
+
+    void mark_valid(std::string const& spki, time_point valid_until)
+    {
+        std::lock_guard<std::mutex> guard{mtx_};
+        auto& value = status_cache_[spki];
+        if (value.status == certificate_status::revoked ||
+            valid_until <= clock_type::now())
+            return;
+
+        value.status = certificate_status::valid;
+        value.valid_until = valid_until;
+    }
+
+    void revoke(std::string const& spki)
+    {
+        std::lock_guard<std::mutex> guard{mtx_};
+        auto& value = status_cache_[spki];
+        value.status = certificate_status::revoked;
+        value.valid_until = time_point::max();
+    }
+
+private:
+    struct value
+    {
+        time_point valid_until{time_point::min()};
+        certificate_status status{certificate_status::unknown};
+    };
+
+    std::unordered_map<std::string, value> status_cache_;
+    mutable std::mutex mtx_;
+};
+} // namespace certify
+} // namespace boost
+
+#endif // BOOST_CERTIFY_STATUS_CACHE_HPP

--- a/tests/Jamfile
+++ b/tests/Jamfile
@@ -51,4 +51,5 @@ test-suite "certify" :
   [ run https_verification_fail.cpp ]
   [ run crl_set_parser.cpp ]
   [ run detail_spki_digest.cpp ]
+  [ run status_cache.cpp ]
   ;

--- a/tests/status_cache.cpp
+++ b/tests/status_cache.cpp
@@ -1,0 +1,43 @@
+#include <boost/certify/detail/status_cache.hpp>
+
+#include <boost/core/lightweight_test.hpp>
+#include <thread>
+
+int
+main()
+{
+    namespace bc = boost::certify;
+    namespace sc = std::chrono;
+
+    {
+        // Empty cache returns status unknown
+        bc::status_cache cache;
+        BOOST_TEST(cache.check("AAA") == bc::certificate_status::unknown);
+    }
+
+    {
+        bc::status_cache cache;
+        BOOST_TEST(cache.check("AAA") == bc::certificate_status::unknown);
+        cache.mark_valid("AAA", sc::system_clock::now() + sc::seconds{120});
+        BOOST_TEST(cache.check("AAA") == bc::certificate_status::valid);
+        cache.revoke("AAA");
+        BOOST_TEST(cache.check("AAA") == bc::certificate_status::revoked);
+
+        // If we ever see a revocation, mark_valid must not update
+        cache.mark_valid("AAA", sc::system_clock::now() + sc::seconds{120});
+        BOOST_TEST(cache.check("AAA") == bc::certificate_status::revoked);
+    }
+
+    {
+        bc::status_cache cache;
+        cache.mark_valid("AAA", sc::system_clock::now() + sc::microseconds{10});
+        std::this_thread::sleep_for(std::chrono::microseconds{11});
+        BOOST_TEST(cache.check("AAA") == bc::certificate_status::unknown);
+
+        // Stale validity check must not update the status
+        cache.mark_valid("AAA", sc::system_clock::now() - sc::microseconds{10});
+        BOOST_TEST(cache.check("AAA") == bc::certificate_status::unknown);
+    }
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
A thread-safe cache for use by the certificate verification algorithm.