### PR TITLE
Conditional inline in declarations/definitions

### DIFF
--- a/include/boost/certify/detail/keystore_apple.ipp
+++ b/include/boost/certify/detail/keystore_apple.ipp
@@ -35,7 +35,7 @@ struct cf_deleter
 template<class T>
 using cf_ptr = std::unique_ptr<T, cf_deleter<T>>;
 
-inline bool
+BOOST_CERTIFY_DECL bool
 dump_cert(X509* cert, std::vector<unsigned char>& buffer)
 {
     auto cert_len = ::i2d_X509(cert, nullptr);
@@ -68,7 +68,7 @@ struct certs_vec
     std::vector<void const*> vec_;
 };
 
-inline bool
+BOOST_CERTIFY_DECL bool
 verify_certificate_chain(::X509_STORE_CTX* ctx)
 {
     auto* const chain = ::X509_STORE_CTX_get_chain(ctx);

--- a/include/boost/certify/detail/keystore_default.ipp
+++ b/include/boost/certify/detail/keystore_default.ipp
@@ -11,7 +11,7 @@ namespace certify
 namespace detail
 {
 
-inline bool
+BOOST_CERTIFY_DECL bool
 verify_certificate_chain(::X509_STORE_CTX*)
 {
     return false;

--- a/include/boost/certify/detail/keystore_windows.ipp
+++ b/include/boost/certify/detail/keystore_windows.ipp
@@ -39,7 +39,7 @@ struct cert_store_deleter
     }
 };
 
-inline std::unique_ptr<::CERT_CHAIN_CONTEXT const, cert_chain_deleter>
+BOOST_CERTIFY_DECL std::unique_ptr<::CERT_CHAIN_CONTEXT const, cert_chain_deleter>
 get_cert_chain_context(::CERT_CONTEXT const* cert_ctx, CERT_CHAIN_PARA* params)
 {
     ::CERT_CHAIN_CONTEXT const* ctx = nullptr;
@@ -62,7 +62,7 @@ get_cert_chain_context(::CERT_CONTEXT const* cert_ctx, CERT_CHAIN_PARA* params)
     return ret;
 }
 
-inline bool
+BOOST_CERTIFY_DECL bool
 dump_cert(X509* cert, std::vector<std::uint8_t>& buffer)
 {
     auto cert_len = ::i2d_X509(cert, nullptr);
@@ -76,7 +76,7 @@ dump_cert(X509* cert, std::vector<std::uint8_t>& buffer)
     return true;
 }
 
-inline std::unique_ptr<::CERT_CONTEXT const, cert_context_deleter>
+BOOST_CERTIFY_DECL std::unique_ptr<::CERT_CONTEXT const, cert_context_deleter>
   create_cert_ctx(STACK_OF(X509) * chain)
 {
     std::unique_ptr<HCERTSTORE, cert_store_deleter> store{
@@ -119,7 +119,7 @@ inline std::unique_ptr<::CERT_CONTEXT const, cert_context_deleter>
     return ret;
 }
 
-inline bool
+BOOST_CERTIFY_DECL bool
 verify_certificate_chain(::X509_STORE_CTX* ctx)
 {
     auto* const chain = ::X509_STORE_CTX_get_chain(ctx);

--- a/include/boost/certify/impl/https_verification.ipp
+++ b/include/boost/certify/impl/https_verification.ipp
@@ -13,7 +13,7 @@ namespace certify
 namespace detail
 {
 
-extern "C" inline int
+extern "C" BOOST_CERTIFY_DECL int
 verify_server_certificates(::X509_STORE_CTX* ctx, void*) noexcept
 {
     if (::X509_verify_cert(ctx) == 1)
@@ -48,7 +48,7 @@ set_server_hostname(::SSL* handle, string_view hostname, system::error_code& ec)
 
 } // namespace detail
 
-inline void
+BOOST_CERTIFY_DECL void
 enable_native_https_server_verification(asio::ssl::context& context)
 {
     ::SSL_CTX_set_cert_verify_callback(


### PR DESCRIPTION
inline must not be added to definitions that are separately compiled.