### PR TITLE
Fix: Deprecation warning on mac 10.15 (Catalina) 

### DIFF
--- a/include/boost/certify/detail/keystore_apple.ipp
+++ b/include/boost/certify/detail/keystore_apple.ipp
@@ -117,13 +117,7 @@ verify_certificate_chain(::X509_STORE_CTX* ctx)
     if (status != noErr)
         return false;
 
-    SecTrustResultType result;
-    status = SecTrustEvaluate(trust.get(), &result);
-    if (status == noErr && (result == kSecTrustResultUnspecified ||
-                            result == kSecTrustResultProceed))
-        return true;
-    else
-        return false;
+    return SecTrustEvaluateWithError(trust.get(), nil);
 }
 
 } // namespace detail

--- a/include/boost/certify/detail/keystore_apple.ipp
+++ b/include/boost/certify/detail/keystore_apple.ipp
@@ -117,7 +117,7 @@ verify_certificate_chain(::X509_STORE_CTX* ctx)
     if (status != noErr)
         return false;
 
-    return SecTrustEvaluateWithError(trust.get(), nil);
+    return SecTrustEvaluateWithError(trust.get(), nullptr);
 }
 
 } // namespace detail


### PR DESCRIPTION
I am getting this error when compiling on MacOS Cataline (10.15). So I created this small PR and it fixes the problem for me. I hope you can merge it in your code
```
.../usr/include/boost/certify/detail/keystore_apple.ipp:112:19: error: 'SecTrustEvaluate' is deprecated:
      first deprecated in macOS 10.15 [-Werror,-Wdeprecated-declarations]
         status = SecTrustEvaluate(trust.get(), &result);
                  ^~~~~~~~~~~~~~~~
                  SecTrustEvaluateWithError
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Security.framework/Headers/SecTrust.h:353:10: note: 
      'SecTrustEvaluate' has been explicitly marked deprecated here
OSStatus SecTrustEvaluate(SecTrustRef trust, SecTrustResultType *result)
```
