### PR TITLE
Fix hostname verification. Close #62

### DIFF
--- a/include/boost/certify/detail/keystore_default.ipp
+++ b/include/boost/certify/detail/keystore_default.ipp
@@ -12,7 +12,7 @@ namespace detail
 {
 
 BOOST_CERTIFY_DECL bool
-verify_certificate_chain(::X509_STORE_CTX*)
+verify_certificate_chain(::X509_STORE_CTX*, std::unique_ptr<char[]> host)
 {
     return false;
 }

--- a/include/boost/certify/https_verification.hpp
+++ b/include/boost/certify/https_verification.hpp
@@ -14,7 +14,7 @@ namespace detail
 {
 
 inline bool
-verify_certificate_chain(::X509_STORE_CTX* ctx);
+verify_certificate_chain(::X509_STORE_CTX* ctx, std::unique_ptr<char[]> host);
 
 inline void
 set_server_hostname(::SSL* handle,
@@ -54,7 +54,7 @@ void
 set_server_hostname(asio::ssl::stream<NextLayer>& stream, string_view hostname);
 
 void
-enable_native_https_server_verification(asio::ssl::context& context);
+enable_native_https_server_verification(asio::ssl::context& context, string_view hostname);
 
 } // namespace certify
 } // namespace boost

--- a/include/boost/certify/impl/https_verification.ipp
+++ b/include/boost/certify/impl/https_verification.ipp
@@ -6,6 +6,8 @@
 #include <boost/asio/ip/address.hpp>
 #include <openssl/x509v3.h>
 
+#include <memory>
+
 namespace boost
 {
 namespace certify
@@ -14,8 +16,10 @@ namespace detail
 {
 
 extern "C" BOOST_CERTIFY_DECL int
-verify_server_certificates(::X509_STORE_CTX* ctx, void*) noexcept
+verify_server_certificates(::X509_STORE_CTX* ctx, void* hostname) noexcept
 {
+    std::unique_ptr<char[]> host;
+    host.reset((char*)hostname);
     if (::X509_verify_cert(ctx) == 1)
         return true;
 
@@ -23,7 +27,7 @@ verify_server_certificates(::X509_STORE_CTX* ctx, void*) noexcept
     if ((err == X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN ||
          err == X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT ||
          err == X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY) &&
-        detail::verify_certificate_chain(ctx))
+        detail::verify_certificate_chain(ctx, std::move(host)))
     {
         ::X509_STORE_CTX_set_error(ctx, X509_V_OK);
         return true;
@@ -38,7 +42,6 @@ set_server_hostname(::SSL* handle, string_view hostname, system::error_code& ec)
     auto* param = ::SSL_get0_param(handle);
     ::X509_VERIFY_PARAM_set_hostflags(param,
                                       X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
-    // TODO(djarek): OpenSSL doesn't report an error here?
     if (!X509_VERIFY_PARAM_set1_host(param, hostname.data(), hostname.size()))
         ec = {static_cast<int>(::ERR_get_error()),
               asio::error::get_ssl_category()};
@@ -49,10 +52,25 @@ set_server_hostname(::SSL* handle, string_view hostname, system::error_code& ec)
 } // namespace detail
 
 BOOST_CERTIFY_DECL void
-enable_native_https_server_verification(asio::ssl::context& context)
+enable_native_https_server_verification(asio::ssl::context& context, string_view hostname)
 {
+    char* host = new char[hostname.size() + 1];
+    std::copy(hostname.begin(), hostname.end(), host);
+    host[hostname.size()] = 0;
     ::SSL_CTX_set_cert_verify_callback(
-      context.native_handle(), &detail::verify_server_certificates, nullptr);
+      context.native_handle(), &detail::verify_server_certificates, host);
+}
+
+BOOST_CERTIFY_DECL void
+enable_native_https_server_verification(asio::ssl::context& context, const char * hostname)
+{
+    char * dup = nullptr;
+    if (hostname) {
+        dup = new char[strlen(hostname) + 1];
+        std::strcpy(dup, hostname);
+    }
+    ::SSL_CTX_set_cert_verify_callback(
+        context.native_handle(), &detail::verify_server_certificates, dup);
 }
 
 } // namespace certify


### PR DESCRIPTION
I have not tested it on mac. But the code for mac is from [here](https://github.com/microsoft/cpprestsdk/blob/master/Release/src/http/client/x509_cert_utilities.cpp#L354), so it should work. 

Without this Pull Request man in the middle attacks are possible. 